### PR TITLE
Avoid gross unit price wo round digits overflow.

### DIFF
--- a/purchase.py
+++ b/purchase.py
@@ -59,7 +59,8 @@ class PurchaseLine(metaclass=PoolMeta):
             unit_price = round_price(unit_price)
 
             if self.discount != 1:
-                gross_unit_price_wo_round = unit_price / (1 - self.discount)
+                gross_unit_price_wo_round = (unit_price / (1 - self.discount)
+                    ).quantize(Decimal(1) / 10 ** DIGITS + DISCOUNT_DIGITS)
             gross_unit_price = round_price(gross_unit_price_wo_round)
 
         self.gross_unit_price = gross_unit_price


### PR DESCRIPTION
Fix error creating purchase, for example in my case:

> El número de dígitos en el valor "Decimal('3.3333333333333333')" para el campo "Precio bruto sin redondeo" en "Línea de compra" excede el límite de "8".